### PR TITLE
hitTest workaround

### DIFF
--- a/SwiftUITouchHandling/ViewController.swift
+++ b/SwiftUITouchHandling/ViewController.swift
@@ -8,11 +8,33 @@
 import UIKit
 import SwiftUI
 
-class ViewController: UIViewController {
+class MyView: UIView {
+    var hostingView: UIView?
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let something = super.hitTest(point, with: event)
+        
+        // SwiftUI returns unusual views during hitTesting - there must be a smarter way to find
+        // a match for the background, but demo purposes this is enough.
+        if something?.frame.width == hostingView?.frame.width {
+            return self.subviews.first
+        } else {
+            return something
+        }
+    }
+}
 
+class ViewController: UIViewController {
+    
+    override func loadView() {
+        let myView = MyView()
+        view = myView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        self.view.backgroundColor = .white
         let button = UIButton(type: .roundedRect, primaryAction: UIAction { _ in
             print("UIKit tapped")
         })
@@ -22,14 +44,16 @@ class ViewController: UIViewController {
         button.layer.borderWidth = 2
         button.layer.borderColor = UIColor.blue.cgColor
         view.addSubview(button)
-
+        
         let swiftUI = UIHostingController(rootView: SwiftUIView())
         swiftUI.view.frame = CGRect(x: 150, y: 150, width: 150, height: 150)
         self.addChild(swiftUI)
         view.addSubview(swiftUI.view)
-        swiftUI.view.isUserInteractionEnabled = false
+        
+        let castView = view as! MyView
+        
+        castView.hostingView = swiftUI.view
     }
-
-
+    
+    
 }
-


### PR DESCRIPTION
I'm working on a similar problem and have found a possible workaround. By using UIKit level hittesting on the super view I can swallow touches before they are passed to SwiftUI.

Using this PR the background button is now tapable, the SwiftUI button is tapable, and the red area triggers the uikit button too.

Its a proof of concept, it uses the width of the background to match the swiftui background, something else should be used, but I didn't find anything quickly - swiftui injects many different views depending on context.

Forwarding the touch to self.subview.first needs to be expanded to for more complex views than in this demo.